### PR TITLE
Removing bin directory

### DIFF
--- a/bin/http-status-codes
+++ b/bin/http-status-codes
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-var path = require('path');
-var fs = require('fs');
-var lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
-require(lib + '/httpstatus.js');

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "url": "https://github.com/prettymuchbryce/node-http-status.git"
   },
   "main": "./lib/httpstatus",
-  "bin": {
-    "http-status-codes": "./bin/http-status-codes"
-  },
   "keywords": [
     "node",
     "http",


### PR DESCRIPTION
I propose the removal of the `bin/` directory as the script in there doesn't technically do anything.

We could have an `examples/` directory, however the quick example in the README should be more than adequate for showing usage.
