### PR TITLE
Can I add non-standard Http status codes?

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ UNAUTHORIZED                        | 401   | Unauthorized
 UNPROCESSABLE_ENTITY                | 422   | Unprocessable Entity
 UNSUPPORTED_MEDIA_TYPE              | 415   | Unsupported Media Type
 USE_PROXY                           | 305   | Use Proxy
+NETWORK_CONNECT_TIMEOUT_ERROR       | 599   | Network Connect Timeout
+
 
 ## TypeScript
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -324,6 +324,12 @@ export declare const UNSUPPORTED_MEDIA_TYPE = 415;
  */
 export declare const USE_PROXY = 305;
 /**
+ * Documentation @ https://httpstatuses.com/599
+ * 
+ * This status code is not specified in any RFCs, but is used by some HTTP proxies to signal a network connect timeout behind the proxy to a client in front of the proxy.
+ */
+export declare const NETWORK_CONNECT_TIMEOUT_ERROR = 599;
+/**
  * Convert the numeric status code to its appropriate title.
  * @param statusCode One of the available status codes in this package
  * @returns {String} The associated title of the passed status code

--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ statusCodes[exports.UNAUTHORIZED = 401] = "Unauthorized";
 statusCodes[exports.UNPROCESSABLE_ENTITY = 422] = "Unprocessable Entity";
 statusCodes[exports.UNSUPPORTED_MEDIA_TYPE = 415] = "Unsupported Media Type";
 statusCodes[exports.USE_PROXY = 305] = "Use Proxy";
+statusCodes[exports.NETWORK_CONNECT_TIMEOUT_ERROR = 599] = "Network Connect Timeout Error",
 
 exports.getStatusText = function(statusCode) {
   if (statusCodes.hasOwnProperty(statusCode)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-status-codes",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Constants enumerating the HTTP status codes. Based on the Java Apache HttpStatus API.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The http status code 599 is not an RFC standard, but is used in many places to indicate a network proxy timeout status. (https://httpstatuses.com/599) Our development organization is using http-status-codes very useful, but there is no such state code so we have to abstract it once more.
Consider adding 599.