### PR TITLE
Remove ncc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-status-codes",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1327,12 +1327,6 @@
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
-    },
-    "@vercel/ncc": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.23.0.tgz",
-      "integrity": "sha512-Fcr1qlG9t54X4X9qbo/+jr1+t5Qc6H3TgIRBXmKkF/WDs6YFulAN6ilq2Ehx38RbgIOFxaZnjlAQ50GyexnMpQ==",
-      "dev": true
     },
     "abab": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/markdown-table": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.1",
-    "@vercel/ncc": "^0.23.0",
     "eslint": "^7.7.0",
     "eslint-config-airbnb-typescript": "^9.0.0",
     "eslint-plugin-import": "^2.22.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,14 +1,4 @@
 #!/bin/bash
 rm -rf ./build
-rm -rf ./build-tmp
-tsc --project tsconfig-build.json
-ncc build ./build-tmp/index.js -o ./build/cjs
-cat ./build-tmp/index.d.ts >> ./build-tmp/codes.d.ts
-# Because we are concatting .d.ts files, we need to remove all imports of codes.ts from index.ts
-sed -i.old '/^import/d' ./build-tmp/codes.d.ts
-# as well as exports that already exist within codes.ts
-sed -i.old '/^export { StatusCodes, ReasonPhrases, }/d;' ./build-tmp/codes.d.ts
-mv ./build-tmp/codes.d.ts ./build/cjs/index.d.ts
-rm -rf ./build-tmp
-tsc --project tsconfig-build.json
-mv ./build-tmp ./build/es/
+tsc --project tsconfig-cjs.json
+tsc --project tsconfig-es.json

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+	"module": "commonjs",
+    "outDir": "./build/cjs/",
+    "resolveJsonModule": false 
+  },
+  "extends": "./tsconfig.json"
+}

--- a/tsconfig-es.json
+++ b/tsconfig-es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "resolveJsonModule": false 
+    "resolveJsonModule": false,
+    "outDir": "./build/es/"
   },
   "extends": "./tsconfig.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
 	"declaration": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "./build-tmp/",
     "resolveJsonModule": true,
 	"moduleResolution": "node"
   },


### PR DESCRIPTION
Removes the `ncc` build tool from common.js builds. This was causing an issue with react native by injecting the `__dirname` variable into the compiled source.

This should fix #60 and lingering issues from #56 