### PR TITLE
Update codes.json with 440 status code

### DIFF
--- a/codes.json
+++ b/codes.json
@@ -505,5 +505,14 @@
       "doc": "Official Documentation @ https://datatracker.ietf.org/doc/html/rfc7540#section-9.1.2",
       "description": "Defined in the specification of HTTP/2 to indicate that a server is not able to produce a response for the combination of scheme and authority that are included in the request URI."
     }
+  },
+  {
+    "code": 440,
+    "phrase": "Login Time-out",
+    "constant": "LOGIN_TIMEOUT",
+    "isDeprecated": false,
+    "comment": {
+      "doc": "Documentation @ https://dynomapper.com/blog/254-the-6-types-of-http-status-codes-explained",
+      "description": "Defined as part of Microsoft's Internet Information Services (IIS) web server expansion of the 4xx error space to signal errors with the client's request. 440 Status code is sent when the client's session has expired and must log in again."
   }
 ]


### PR DESCRIPTION
Added unofficial 440 status code, that was defined in Microsoft's Internet Information Services (IIS) web server and is being adopted widely. It's not part of the standard set of HTTP status codes, but it's particularly used in situations where an application, like an ASP.NET web page, uses forms authentication.

More reading: https://dynomapper.com/blog/254-the-6-types-of-http-status-codes-explained:

**440 Login Timeout**: When a client’s session has expired, a 440 Login Timeout response will appear, instructing the user to log in again to proceed with his request.