### PR TITLE
Adding a fallback param to utility functions

### DIFF
--- a/src/utils-functions.ts
+++ b/src/utils-functions.ts
@@ -3,42 +3,46 @@ import {
   reasonPhraseToStatusCode,
 } from './utils';
 
-const checkResult = <T>(result: T, message: string): T => {
-  if (!result) {
-    throw new Error(message);
+const getDefaultFallback = (message: string) => <T>(param?: T): any => {
+  if (!param) {
+    throw new Error(`${message} ${param}`);
   }
 
-  return result;
+  return param;
 }
+
+const defaultReasonPhraseFallback = getDefaultFallback(`Status code does not exist:`);
+
+const defaultStatusCodeFallback = getDefaultFallback(`Reason phrase does not exist:`);
 
 /**
  * Returns the reason phrase for the given status code.
- * If the given status code does not exist, an error is thrown if the flag throwWhenMissing is set up to true,
- * otherwise return undefined.
+ * If the given status code does not exist, a fallback function is called passing the status code provided,
+ * which by default throws an error indicating that the status code it's missing.
  *
  * @param {number|string} statusCode The HTTP status code
- * @param {boolean} [throwWhenMissing=true] Flag to indicate that an error should be thrown if the status code provided is missing 
+ * @param {function} [fallback] Optional fallback function that it's called if the status code is missing 
  * @returns {string} The associated reason phrase (e.g. "Bad Request", "OK")
  * */
-export function getReasonPhrase(statusCode: (number | string), throwWhenMissing = true): (string) {
+export function getReasonPhrase(statusCode: (number | string), fallback = defaultReasonPhraseFallback): (string) {
   const result = statusCodeToReasonPhrase[statusCode.toString()];
 
-  return throwWhenMissing ? checkResult(result, `Status code does not exist: ${statusCode}`) : result;
+  return result ? result : fallback(statusCode);
 }
 
 /**
  * Returns the status code for the given reason phrase.
- * If the given reason phrase does not exist, an error is thrown if the flag throwWhenMissing is set up to true,
- * otherwise return undefined.
+ * If the given reason phrase does not exist, a fallback function is called passing the reason phrase provided,
+ * which by default throws an error indicating that the reason code it's missing.
  *
  * @param {string} reasonPhrase The HTTP reason phrase (e.g. "Bad Request", "OK")
- * @param {boolean} [throwWhenMissing=true] Flag to indicate that an error should be thrown if the reason phrase is missing
+ * @param {function} [fallback] Optional fallback function that it's called if the reason phrase is missing
  * @returns {string} The associated status code
  * */
-export function getStatusCode(reasonPhrase: string, throwWhenMissing = true): (number) {
+export function getStatusCode(reasonPhrase: string, fallback = defaultStatusCodeFallback): (number) {
   const result = reasonPhraseToStatusCode[reasonPhrase];
 
-  return throwWhenMissing ? checkResult(result, `Reason phrase does not exist: ${reasonPhrase}`) : result;
+  return result ? result : fallback(reasonPhrase);
 }
 
 /**

--- a/src/utils-functions.ts
+++ b/src/utils-functions.ts
@@ -3,34 +3,42 @@ import {
   reasonPhraseToStatusCode,
 } from './utils';
 
-/**
- * Returns the reason phrase for the given status code.
- * If the given status code does not exist, an error is thrown.
- *
- * @param {number|string} statusCode The HTTP status code
- * @returns {string} The associated reason phrase (e.g. "Bad Request", "OK")
- * */
-export function getReasonPhrase(statusCode: (number | string)): (string) {
-  const result = statusCodeToReasonPhrase[statusCode.toString()];
+const checkResult = <T>(result: T, message: string): T => {
   if (!result) {
-    throw new Error(`Status code does not exist: ${statusCode}`);
+    throw new Error(message);
   }
+
   return result;
 }
 
 /**
+ * Returns the reason phrase for the given status code.
+ * If the given status code does not exist, an error is thrown if the flag throwWhenMissing is set up to true,
+ * otherwise return undefined.
+ *
+ * @param {number|string} statusCode The HTTP status code
+ * @param {boolean} [throwWhenMissing=true] Flag to indicate that an error should be thrown if the status code provided is missing 
+ * @returns {string} The associated reason phrase (e.g. "Bad Request", "OK")
+ * */
+export function getReasonPhrase(statusCode: (number | string), throwWhenMissing = true): (string) {
+  const result = statusCodeToReasonPhrase[statusCode.toString()];
+
+  return throwWhenMissing ? checkResult(result, `Status code does not exist: ${statusCode}`) : result;
+}
+
+/**
  * Returns the status code for the given reason phrase.
- * If the given reason phrase does not exist, undefined is returned.
+ * If the given reason phrase does not exist, an error is thrown if the flag throwWhenMissing is set up to true,
+ * otherwise return undefined.
  *
  * @param {string} reasonPhrase The HTTP reason phrase (e.g. "Bad Request", "OK")
+ * @param {boolean} [throwWhenMissing=true] Flag to indicate that an error should be thrown if the reason phrase is missing
  * @returns {string} The associated status code
  * */
-export function getStatusCode(reasonPhrase: string): (number) {
+export function getStatusCode(reasonPhrase: string, throwWhenMissing = true): (number) {
   const result = reasonPhraseToStatusCode[reasonPhrase];
-  if (!result) {
-    throw new Error(`Reason phrase does not exist: ${reasonPhrase}`);
-  }
-  return result;
+
+  return throwWhenMissing ? checkResult(result, `Reason phrase does not exist: ${reasonPhrase}`) : result;
 }
 
 /**


### PR DESCRIPTION
I added to the utility functions an optional fallback function parameter so throwing an error can be avoided, anyway we will be maintaining the error throw as a default behaviour so we keep the functions backward compatible, and at the same time we are adding the flexibility to the user to decide what it's the behaviour when something it's missing (like returning undefined or a default value), as some times working with this in some projects (overall front end projects) could lead into undesirable consequences if not handled properly. 

This also add the requested feature in the issue #88